### PR TITLE
fix: update name for rolebinding

### DIFF
--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: controller-manager-rolebinding
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-manager-role
+  name: manager-role
 subjects:
   - kind: ServiceAccount
     name: default


### PR DESCRIPTION
There was a naming error in the rolebinding yamls. This will ensure
they'll get prefaced with the proper `cabpt-` string and work properly.