### PR TITLE
fix: ensure machine configs work in packet

### DIFF
--- a/controllers/talosconfig_controller.go
+++ b/controllers/talosconfig_controller.go
@@ -187,6 +187,12 @@ func (r *TalosConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rerr
 		return ctrl.Result{}, errors.New("unknown generate type specified")
 	}
 
+	// Packet acts a fool if you don't prepend #!talos to the userdata
+	// so we try to suss out if that's the type of machine getting created.
+	if machine.Spec.InfrastructureRef.Kind == "PacketMachine" {
+		retData.BoostrapData = "#!talos\n" + retData.BoostrapData
+	}
+
 	err = r.writeBootstrapData(ctx, tcScope, []byte(retData.BoostrapData))
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
This PR does a check if we're dealing with a PacketMachine. If so, we
prepend the shebang necessary to make userdata work there.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>