### PR TITLE
fix: ensure proper ownership of certs

### DIFF
--- a/controllers/secrets.go
+++ b/controllers/secrets.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -70,12 +69,7 @@ func (r *TalosConfigReconciler) writeInputSecret(ctx context.Context, scope *Tal
 				clusterv1.ClusterLabelName: scope.Cluster.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
-					APIVersion: clusterv1.GroupVersion.String(),
-					Kind:       "Cluster",
-					Name:       scope.Cluster.Name,
-					UID:        scope.Cluster.UID,
-				},
+				*metav1.NewControllerRef(scope.Config, bootstrapv1alpha3.GroupVersion.WithKind("TalosConfig")),
 			},
 		},
 		Data: map[string][]byte{
@@ -104,12 +98,7 @@ func (r *TalosConfigReconciler) writeK8sCASecret(ctx context.Context, scope *Tal
 					clusterv1.ClusterLabelName: scope.Cluster.Name,
 				},
 				OwnerReferences: []metav1.OwnerReference{
-					metav1.OwnerReference{
-						APIVersion: clusterv1.GroupVersion.String(),
-						Kind:       "Cluster",
-						Name:       scope.Cluster.Name,
-						UID:        scope.Cluster.UID,
-					},
+					*metav1.NewControllerRef(scope.Config, bootstrapv1alpha3.GroupVersion.WithKind("TalosConfig")),
 				},
 			},
 			Data: map[string][]byte{
@@ -142,13 +131,7 @@ func (r *TalosConfigReconciler) writeBootstrapData(ctx context.Context, scope *T
 					clusterv1.ClusterLabelName: scope.Cluster.Name,
 				},
 				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: bootstrapv1alpha3.GroupVersion.String(),
-						Kind:       "TalosConfig",
-						Name:       scope.Config.Name,
-						UID:        scope.Config.UID,
-						Controller: pointer.BoolPtr(true),
-					},
+					*metav1.NewControllerRef(scope.Config, bootstrapv1alpha3.GroupVersion.WithKind("TalosConfig")),
 				},
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
This PR fixes a bug where the bootstrap provider didn't own the certs it
created, they were owned by the cluster instead. This leads to a
case where, if control plane machines were cleaned up, the CA secret was
still present. I've moved ownership to be the TalosConfig and updated
how I set those owners based on what the kubeadm bootstrapper does.

I crosschecked what the owner is supposed to be by running this function
down: https://github.com/kubernetes-sigs/cluster-api/blob/v0.3.8/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go#L376

Will close #27 