### PR TITLE
fix: ensure we have a dns domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/talos-systems/crypto v0.2.0
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-20200817172914-fca19cb8be2e
+	github.com/talos-systems/talos/pkg/machinery v0.0.0-20201006184949-3961f835f502
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
+github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
@@ -445,12 +447,10 @@ github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e h1:Z
 github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j8UNYE=
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/net v0.1.0 h1:fEgj3xbH+lIopFGnk/4CaV4QvFG2kQXs/t+pfeZGmCc=
-github.com/talos-systems/net v0.1.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20200817165614-bddd4f1bf6f2 h1:Y1qHUMDahSKJyRzmlU24NTETLBypv4mPFOxWE39M1PM=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20200817165614-bddd4f1bf6f2/go.mod h1:Bj+0EE3f8TAzwATsZFzQMxRBiPHDFXwCOCkiYXlum3w=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20200817172914-fca19cb8be2e h1:fEYaYnZPyyUrRl5VVgnWUU2ieIEgwIsCc9QPG+ai2Ho=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20200817172914-fca19cb8be2e/go.mod h1:Bj+0EE3f8TAzwATsZFzQMxRBiPHDFXwCOCkiYXlum3w=
+github.com/talos-systems/net v0.2.0 h1:QJ2ofYboG1Zjew9b+3RAjtLIfL0mIONGuc6/LyO68MM=
+github.com/talos-systems/net v0.2.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20201006184949-3961f835f502 h1:Y62JmL3Ms0gsiAL6/0ug2WEody1czNdZCQ2bnk63Dco=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20201006184949-3961f835f502/go.mod h1:Oa6kzDfA2SSosSITBXf6XMl/cvSfI330LiceB5wO/Dg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,6 +1,0 @@
-package constants
-
-const (
-	//DefaultKubeVersion is the default kube version
-	DefaultKubeVersion = "1.19.0"
-)


### PR DESCRIPTION
This PR pulls in the latest machinery code from talos and fixes an
issue where we weren't providing a default DNS domain for talos config
generation. We now rely on the constants package inside of machinery for
a default dns name, as well as k8s version.