### PR TITLE
fix: make sure secrets are cluster owned

### DIFF
--- a/controllers/secrets.go
+++ b/controllers/secrets.go
@@ -69,7 +69,7 @@ func (r *TalosConfigReconciler) writeInputSecret(ctx context.Context, scope *Tal
 				clusterv1.ClusterLabelName: scope.Cluster.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(scope.Config, bootstrapv1alpha3.GroupVersion.WithKind("TalosConfig")),
+				*metav1.NewControllerRef(scope.Cluster, bootstrapv1alpha3.GroupVersion.WithKind("Cluster")),
 			},
 		},
 		Data: map[string][]byte{
@@ -98,7 +98,7 @@ func (r *TalosConfigReconciler) writeK8sCASecret(ctx context.Context, scope *Tal
 					clusterv1.ClusterLabelName: scope.Cluster.Name,
 				},
 				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(scope.Config, bootstrapv1alpha3.GroupVersion.WithKind("TalosConfig")),
+					*metav1.NewControllerRef(scope.Cluster, bootstrapv1alpha3.GroupVersion.WithKind("Cluster")),
 				},
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
This PR fixes a bug where certain secrets should be cluster scoped b/c they get reused for
bootstrap data generation when new machines scale up/down.