### PR TITLE
fix: update metadata.yaml for v0.3 of CABPT

### DIFF
--- a/config/metadata/metadata.yaml
+++ b/config/metadata/metadata.yaml
@@ -4,3 +4,6 @@ releaseSeries:
 - major: 0
   minor: 2
   contract: v1alpha3
+- major: 0
+  minor: 3
+  contract: v1alpha3


### PR DESCRIPTION
This PR makes sure we'll generate a working metadata for clusterctl to
use for the v0.3 release series.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
