### PR TITLE
fix: construct properly data secret name

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smira/talos/pkg/machinery v0.0.0-20210920195258-7e63e43eb399 h1:4eO8ltJZZTUOtWGbGi6nKSylWuYC65dSEICHkQqHnDc=
-github.com/smira/talos/pkg/machinery v0.0.0-20210920195258-7e63e43eb399/go.mod h1:qX77JMZawrDTQaJucqecdlFsHy+dbnZ9YL8Kw4qL7d4=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -479,8 +477,6 @@ github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1
 github.com/talos-systems/go-retry v0.3.1/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/net v0.3.0 h1:TG6PoiNdg9NmSeSjyecSgguUXzoJ8wp5a8RYlIdkq3Y=
 github.com/talos-systems/net v0.3.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/talos/pkg/machinery v0.12.2 h1:pLRVkJ1Xa1rrVUsqJ0RccL0c2q9It268wwBV4cvg8kk=
-github.com/talos-systems/talos/pkg/machinery v0.12.2/go.mod h1:qX77JMZawrDTQaJucqecdlFsHy+dbnZ9YL8Kw4qL7d4=
 github.com/talos-systems/talos/pkg/machinery v0.12.3-0.20210920195258-7e63e43eb399 h1:mmQ/XAV9xRm3chHx/f4xBZH4I2T960fJh4chkedW+nY=
 github.com/talos-systems/talos/pkg/machinery v0.12.3-0.20210920195258-7e63e43eb399/go.mod h1:qX77JMZawrDTQaJucqecdlFsHy+dbnZ9YL8Kw4qL7d4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
The one provided in the config owner spec is only used for pivoting.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>