### PR TITLE
feat: bump Talos machinery to 0.12.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.3.2
-	github.com/talos-systems/talos/pkg/machinery v0.12.3-0.20210920195258-7e63e43eb399
+	github.com/talos-systems/talos/pkg/machinery v0.12.3
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.4

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1
 github.com/talos-systems/go-retry v0.3.1/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/net v0.3.0 h1:TG6PoiNdg9NmSeSjyecSgguUXzoJ8wp5a8RYlIdkq3Y=
 github.com/talos-systems/net v0.3.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/talos/pkg/machinery v0.12.3-0.20210920195258-7e63e43eb399 h1:mmQ/XAV9xRm3chHx/f4xBZH4I2T960fJh4chkedW+nY=
-github.com/talos-systems/talos/pkg/machinery v0.12.3-0.20210920195258-7e63e43eb399/go.mod h1:qX77JMZawrDTQaJucqecdlFsHy+dbnZ9YL8Kw4qL7d4=
+github.com/talos-systems/talos/pkg/machinery v0.12.3 h1:nX/2TQ7EoLEoTzvL+9XGA8vUhyisEAyhYXP2K27pGfU=
+github.com/talos-systems/talos/pkg/machinery v0.12.3/go.mod h1:qX77JMZawrDTQaJucqecdlFsHy+dbnZ9YL8Kw4qL7d4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/integration/assertions_test.go
+++ b/internal/integration/assertions_test.go
@@ -119,6 +119,7 @@ func assertCompatibleMachineConfigs(ctx context.Context, t *testing.T, c client.
 
 	checks := []func(p machineconfig.Provider) interface{}{
 		func(p machineconfig.Provider) interface{} { return p.Machine().Security().Token() },
+		func(p machineconfig.Provider) interface{} { return p.Machine().Security().CA().Crt },
 		func(p machineconfig.Provider) interface{} { return p.Cluster().ID() },
 		func(p machineconfig.Provider) interface{} { return p.Cluster().Secret() },
 		func(p machineconfig.Provider) interface{} { return p.Cluster().Endpoint().String() },


### PR DESCRIPTION
This includes machine's CA distrituted to worker nodes.
Tests were updated to assert that.

Should be backported to 0.3.x.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>