### PR TITLE
fix: don't write incomplete `<cluster>-ca` secret for configtype none

### DIFF
--- a/controllers/talosconfig_controller.go
+++ b/controllers/talosconfig_controller.go
@@ -324,8 +324,11 @@ func (r *TalosConfigReconciler) userConfigs(ctx context.Context, scope *TalosCon
 	}
 
 	// Create the secret with kubernetes certs so a kubeconfig can be generated
-	if err = r.writeK8sCASecret(ctx, scope, userConfig.Cluster().CA()); err != nil {
-		return retBundle, err
+	// but do this only when machineconfig contains full Kubernetes CA secret (controlplane nodes)
+	if userConfig.Cluster().CA() != nil && len(userConfig.Cluster().CA().Crt) > 0 && len(userConfig.Cluster().CA().Key) > 0 {
+		if err = r.writeK8sCASecret(ctx, scope, userConfig.Cluster().CA()); err != nil {
+			return retBundle, err
+		}
 	}
 
 	userConfigStr, err := userConfig.String()


### PR DESCRIPTION
Fixes #97

Skip creating the secret if the supplied user config doesn't have full
cluster CA. Cluster secret will be created once the controlplane machine
configuration is passed in.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>