### PR TITLE
test: don't set the talosconfig owner ref to the machine

### DIFF
--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: talosconfigs.bootstrap.cluster.x-k8s.io
 spec:
@@ -24,10 +24,14 @@ spec:
         description: TalosConfig is the Schema for the talosconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -55,10 +59,12 @@ spec:
                 description: ErrorReason will be set on non-retryable errors
                 type: string
               ready:
-                description: Ready indicates the BootstrapData field is ready to be consumed
+                description: Ready indicates the BootstrapData field is ready to be
+                  consumed
                 type: boolean
               talosConfig:
-                description: Talos config will be a string containing the config for download
+                description: Talos config will be a string containing the config for
+                  download
                 type: string
             type: object
         type: object
@@ -72,10 +78,14 @@ spec:
         description: TalosConfig is the Schema for the talosconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -109,7 +119,8 @@ spec:
             description: TalosConfigStatus defines the observed state of TalosConfig
             properties:
               dataSecretName:
-                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
                 type: string
               failureMessage:
                 description: FailureMessage will be set on non-retryable errors
@@ -118,10 +129,12 @@ spec:
                 description: FailureReason will be set on non-retryable errors
                 type: string
               ready:
-                description: Ready indicates the BootstrapData field is ready to be consumed
+                description: Ready indicates the BootstrapData field is ready to be
+                  consumed
                 type: boolean
               talosConfig:
-                description: Talos config will be a string containing the config for download
+                description: Talos config will be a string containing the config for
+                  download
                 type: string
             type: object
         type: object

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigtemplates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: talosconfigtemplates.bootstrap.cluster.x-k8s.io
 spec:
@@ -21,13 +21,18 @@ spec:
   - name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: TalosConfigTemplate is the Schema for the talosconfigtemplates API
+        description: TalosConfigTemplate is the Schema for the talosconfigtemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -57,13 +62,18 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: TalosConfigTemplate is the Schema for the talosconfigtemplates API
+        description: TalosConfigTemplate is the Schema for the talosconfigtemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -116,8 +116,6 @@ func createMachine(ctx context.Context, t *testing.T, c client.Client, cluster *
 		},
 	}
 
-	require.NoError(t, controllerutil.SetOwnerReference(cluster, machine, scheme.Scheme))
-
 	require.NoError(t, c.Create(ctx, machine))
 
 	return machine


### PR DESCRIPTION
Now as we have core CAPI controllers running, they will do it
automatically which provides better test coverage.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>