### PR TITLE
fix: regenerate manifests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,7 @@ steps:
       PLATFORM: linux/amd64,linux/arm64
     commands:
       - make
+      - make check-dirty
     when:
       event:
         include:
@@ -116,6 +117,7 @@ steps:
     pull: always
     commands:
       - make release
+      - make check-dirty
     when:
       event:
         - tag
@@ -181,6 +183,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 405eea502f51dfc9368f81971ca97c96ac99f5fff6ddc1afa613894e80dd67c2
+hmac: 08c8794304be76a3ddf7d3fd138b79c792dd747c9d57004e7836363fb0985e32
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ run: install ## Run the controller locally. This is for testing purposes only.
 clean:
 	@rm -rf $(ARTIFACTS)
 
+check-dirty: ## Verifies that source tree is not dirty
+	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; exit 1 ; fi
+
 conformance:  ## Performs policy checks against the commit and source code.
 	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/talos-systems/conform:v0.1.0-alpha.23 enforce
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
@@ -182,8 +182,9 @@ spec:
                   consumed
                 type: boolean
               talosConfig:
-                description: Talos config will be a string containing the config for
-                  download
+                description: "Talos config will be a string containing the config
+                  for download. \n Deprecated: please use `<cluster>-talosconfig`
+                  secret."
                 type: string
             type: object
         type: object


### PR DESCRIPTION
Add dirtiness check so that we will never have outdated manifests.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit f6dc0a3372dba82306a4abc9b2a064f1e337421c)