### PR TITLE
fix: ensure shebang on packet machine configs

### DIFF
--- a/controllers/talosconfig_controller.go
+++ b/controllers/talosconfig_controller.go
@@ -336,7 +336,7 @@ func (r *TalosConfigReconciler) reconcileGenerate(ctx context.Context, tcScope *
 			return err
 		}
 
-		if machine.Spec.InfrastructureRef.Name == "PacketMachine" {
+		if machine.Spec.InfrastructureRef.Kind == "PacketMachine" {
 			retData.BootstrapData = "#!talos\n" + retData.BootstrapData
 		}
 	}


### PR DESCRIPTION
This PR fixes a small bug where we weren't correctly searching for `Kind` of `PacketMacine`

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>