### PR TITLE
chore: bump CAPI to 1.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
-	sigs.k8s.io/cluster-api v1.0.3
+	sigs.k8s.io/cluster-api v1.0.4
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1216,8 +1216,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/cluster-api v1.0.3 h1:unJqMUG5LJ312kgHSAnBzfYazbGCcGkTcdGD3lF459k=
-sigs.k8s.io/cluster-api v1.0.3/go.mod h1:/LkJXtsvhxTV4U0z1Y2Y1Gr2xebJ0/ce09Ab2M0XU/U=
+sigs.k8s.io/cluster-api v1.0.4 h1:3vMvQjEmkSQayN9r0DXlfn8uWHzqNT+HPBveVryJ1Dc=
+sigs.k8s.io/cluster-api v1.0.4/go.mod h1:/LkJXtsvhxTV4U0z1Y2Y1Gr2xebJ0/ce09Ab2M0XU/U=
 sigs.k8s.io/controller-runtime v0.10.3 h1:s5Ttmw/B4AuIbwrXD3sfBkXwnPMMWrqpVj4WRt1dano=
 sigs.k8s.io/controller-runtime v0.10.3/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=

--- a/hack/clusterctl.yaml
+++ b/hack/clusterctl.yaml
@@ -1,3 +1,0 @@
-# temporary, see https://github.com/kubernetes-sigs/cluster-api/issues/6051
-cert-manager:
-  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"

--- a/internal/integration/setup_test.go
+++ b/internal/integration/setup_test.go
@@ -198,7 +198,7 @@ func installCAPI(ctx context.Context, t *testing.T) {
 	// t.FailNow() should be called in the main goroutine.
 	initErr := make(chan error, 1)
 	go func() {
-		clusterctlClient, err := clusterctlclient.New("../../hack/clusterctl.yaml")
+		clusterctlClient, err := clusterctlclient.New("")
 		if err != nil {
 			initErr <- err
 			return


### PR DESCRIPTION
Remove the temporary fix for cert-manager download.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>