### PR TITLE
chore: bump cert-manager to v1

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,7 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -9,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,7 +25,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
     fieldref:
       fieldpath: metadata.namespace
@@ -33,7 +33,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
   - name: SERVICE_NAMESPACE # namespace of the service
     objref:


### PR DESCRIPTION
Bump cert-manager to `v1`

Signed-off-by: Noel Georgi <git@frezbo.dev>